### PR TITLE
feat(calendar): support “Todas as salas” in Month view + per-room color dots

### DIFF
--- a/src/common/components/calendar/calendar-layout-month.jsx
+++ b/src/common/components/calendar/calendar-layout-month.jsx
@@ -338,7 +338,7 @@ function CalendarLayoutMonth(props) {
                                 });
                             }}
                         >
-                            {selectedRoom === 'ALL' && (
+                            {/* {selectedRoom === 'ALL' && (
                                 <span
                                     style={{
                                         display: 'inline-block',
@@ -350,7 +350,7 @@ function CalendarLayoutMonth(props) {
                                         flexShrink: 0
                                     }}
                                 />
-                            )}
+                            )} */}
                             {`${event?.description} - ${evHour.hour}h `}
                         </div>
                     );

--- a/src/common/components/calendar/calendar-layout-month.jsx
+++ b/src/common/components/calendar/calendar-layout-month.jsx
@@ -107,7 +107,6 @@ const Root = styled('div')(({ theme }) => ({
         width: '100%',
         marginTop: theme.spacing(1),
         overflow: 'hidden',
-        whiteSpace: 'nowrap',
         textOverflow: 'ellipsis'
     },
 
@@ -188,7 +187,7 @@ const Root = styled('div')(({ theme }) => ({
 }));
 
 function CalendarLayoutMonth(props) {
-    const { selectedRoom } = props;
+    const { selectedRoom, roomColors } = props;
 
     const viewEvent = (viewEventProps) => {
         const { calendarEvent } = viewEventProps;
@@ -308,44 +307,60 @@ function CalendarLayoutMonth(props) {
             !acc.some((accItem) => accItem.hour === hour) && acc.push({ hour, len });
             return acc;
         }, []);
-
         const markers = eventsByHour.map((evHour) => {
             return dayEvents
                 .filter((event) => new Date(event.begin).getHours() === evHour.hour)
-                .map((event) => (
-                    <div
-                        style={{
-                            cursor: location.pathname === '/calendario' ? 'default' : 'pointer'
-                        }}
-                        key={`event-${event.id}`}
-                        className={clsx(classes.monthMarker, {
-                            [classes.markerPending]: event.status === 'PENDING',
-                            [classes.markerScheduled]: event.status === 'SCHEDULED',
-                            [classes.markerCompleted]: event.status === 'COMPLETED',
-                            [classes.markerCancelled]: event.status === 'CANCELLED',
-                            [classes.markerRescheduled]: event.status === 'RESCHEDULED',
-                            [classes.markerNoShow]: event.status === 'NO_SHOW'
-                        })}
-                        onClick={(eventEl) => {
-                            viewEvent({
-                                eventEl,
-                                calendarEvent: event,
-                                defaultEventDuration,
-                                stateCalendar,
-                                setStateCalendar,
-                                selectedRoom
-                            });
-                        }}
-                    >
-                        {`${event?.description}`}
-                    </div>
-                ));
+                .map((event) => {
+                    const bgDot = roomColors[event.room.id] || '#888';
+                    return (
+                        <div
+                            title={`${event.room?.name}`}
+                            style={{
+                                cursor: location.pathname === '/calendario' ? 'default' : 'pointer'
+                            }}
+                            key={`event-${event.id}`}
+                            className={clsx(classes.monthMarker, {
+                                [classes.markerPending]: event.status === 'PENDING',
+                                [classes.markerScheduled]: event.status === 'SCHEDULED',
+                                [classes.markerCompleted]: event.status === 'COMPLETED',
+                                [classes.markerCancelled]: event.status === 'CANCELLED',
+                                [classes.markerRescheduled]: event.status === 'RESCHEDULED',
+                                [classes.markerNoShow]: event.status === 'NO_SHOW'
+                            })}
+                            onClick={(eventEl) => {
+                                viewEvent({
+                                    eventEl,
+                                    calendarEvent: event,
+                                    defaultEventDuration,
+                                    stateCalendar,
+                                    setStateCalendar,
+                                    selectedRoom
+                                });
+                            }}
+                        >
+                            {selectedRoom === 'ALL' && (
+                                <span
+                                    style={{
+                                        display: 'inline-block',
+                                        width: 6,
+                                        height: 6,
+                                        borderRadius: '999px',
+                                        backgroundColor: bgDot,
+                                        marginRight: 4,
+                                        flexShrink: 0
+                                    }}
+                                />
+                            )}
+                            {`${event?.description} - ${evHour.hour}h `}
+                        </div>
+                    );
+                });
         });
         return markers;
     };
 
     return (
-        <Root style={{ height: 'calc(-162px + 100vh)', overflow: 'auto' }}>
+        <Root style={{ overflow: 'auto' }}>
             <Grid container spacing={0} direction="row" justify="center" alignItems="center" wrap="nowrap">
                 {weeks[0].map((weekDay, index) => {
                     return (

--- a/src/common/components/calendar/calendar-main.jsx
+++ b/src/common/components/calendar/calendar-main.jsx
@@ -64,7 +64,7 @@ function CalendarMain(props) {
   const { selectedDate, layout } = stateCalendar;
   const businessId = useSelector((state) => state.auth.user?.businessId);
   const { data: allRooms } = useSelector((state) => state.rooms) || [];
-  const { runAnimation, setGetScheduleData, fetchRooms, selectedRoom } = props;
+  const { runAnimation, setGetScheduleData, fetchRooms, selectedRoom, roomColors } = props;
   const [, setStartEndDates] = useState({
     start: selectedDate,
     end: selectedDate,
@@ -128,7 +128,7 @@ function CalendarMain(props) {
   return (
     <Root style={{ width: "100%" }}>
       {layout === "month" && (
-        <CalendarLayoutMonth weeks={weeks} runAnimation={runAnimation} selectedRoom={selectedRoom} />
+        <CalendarLayoutMonth roomColors={roomColors} weeks={weeks} runAnimation={runAnimation} selectedRoom={selectedRoom} />
       )}
       {(layout === "week" || layout === "day") && (
         <CalendarLayoutDayWeek

--- a/src/common/components/calendar/calendar-toolbar.jsx
+++ b/src/common/components/calendar/calendar-toolbar.jsx
@@ -335,6 +335,7 @@ function CalendarToolbar(props) {
                                 <FormControl size="small" className={classes.roomSelector} sx={{ width: '100%', maxWidth: 420 }}>
                                     <InputLabel>Sala</InputLabel>
                                     <Select value={selectedRoom || ''} label="Sala" onChange={handleRoomChange} fullWidth>
+                                        {layout === 'month' && <MenuItem value="ALL">Todas as salas</MenuItem>}
                                         {rooms
                                             ?.slice()
                                             .sort((a, b) => a.name.localeCompare(b.name))
@@ -497,6 +498,7 @@ function CalendarToolbar(props) {
                         <FormControl size="small" className={classes.roomSelectorSmall} fullWidth>
                             <InputLabel>Sala</InputLabel>
                             <Select value={selectedRoom || ''} label="Sala" onChange={handleRoomChange} fullWidth>
+                                {layout === 'month' && <MenuItem value="ALL">Todas as salas</MenuItem>}
                                 {rooms?.map((room) => (
                                     <MenuItem key={room.id} value={room.id}>
                                         {room.name}

--- a/src/pages/calendar/calendar.jsx
+++ b/src/pages/calendar/calendar.jsx
@@ -177,6 +177,19 @@ const Calendar = () => {
         }
     };
 
+    const [roomColors, setRoomColors] = useState({});
+
+    useEffect(() => {
+        if (!rooms.length) return;
+        // evenly distribute hues around the color wheel
+        const map = rooms.reduce((acc, room, idx) => {
+            const hue = Math.round((idx * 360) / rooms.length);
+            acc[room.id] = `hsl(${hue}, 70%, 50%)`;
+            return acc;
+        }, {});
+        setRoomColors(map);
+    }, [rooms]);
+
     return (
         <LoggedLayout>
             <StyledCalendarContextProvider value={{ stateCalendar, setStateCalendar }}>
@@ -227,6 +240,7 @@ const Calendar = () => {
                                 setGetScheduleData={setGetScheduleData}
                                 fetchRooms={fetchRooms}
                                 selectedRoom={selectedRoom}
+                                roomColors={roomColors}
                             />
                             <CalendarEventDialog isLoading={isLoading} refreshCalendar={refreshCalendar} roomsList={rooms} />
                             <ExportReservationDialog open={openExportDialog} setOpenExportDialog={setOpenExportDialog} />


### PR DESCRIPTION
Description
This PR adds a new “Todas as salas” (All rooms) option to the room selector—visible only in Month view—and visually tags each event with a tiny dot in its room’s unique color. When “Todas as salas” is active, the calendar fetches reservations across all rooms; in other views it falls back to the previously selected single room. Status styling remains unchanged.

Changes

Backend

listReservations controller: treat roomId='ALL' as “no filter” so all rooms’ reservations are returned in the date range.

Adjusted Express route ordering to ensure calendar-list and export endpoints precede the /:roomId catch-all.

Front-end

Room selector

Prepends { id: 'ALL', name: 'Todas as salas' } to rooms list.

Shows “Todas as salas” only when layout === 'month'.

Resets back to the first real room if the user switches away from Month while “ALL” is selected.

Color mapping

Computes roomColors: { [roomId]: hsl(...) } once per room list.

Passed via context/props to calendar renderers.

Month layout

In CalendarLayoutMonth, each event marker now renders an inline <span> dot colored by roomColors[event.room.id]—only when selectedRoom === 'ALL'.

Retains existing status classes (markerScheduled, etc.) for border/background.

Tooltip on hover shows the room name.

Grid fixes

Switched column containers to justify="flex-start" + flex: 1 items to ensure all 7 days are visible at 100% zoom.

